### PR TITLE
Fix signatures of main()

### DIFF
--- a/src/test-avi.c
+++ b/src/test-avi.c
@@ -199,9 +199,7 @@ static void encode_screens_to_avi (char *outname) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-int main (int argc, char *argv[]) {
-    argc = argc; /* get rid of warning */
-    argv = argv; /* get rid of warning */
+int main (void) {
 
     complevel = 4;
 

--- a/src/unpack.c
+++ b/src/unpack.c
@@ -135,10 +135,7 @@ static void decode_screens (void) {
 
 
 ////////////////////////////////////////////////////////////////////////////////
-int main (int argc, char *argv[]) {
-  argc = argc; /* get rid of warning */
-  argv = argv; /* get rid of warning */
-
+int main (void) {
   zmbv_open();
   decode_screens();
   zmbv_close();

--- a/src/unpack_small.c
+++ b/src/unpack_small.c
@@ -134,10 +134,7 @@ static void decode_screens (void) {
 
 
 ////////////////////////////////////////////////////////////////////////////////
-int main (int argc, char *argv[]) {
-  argc = argc; /* get rid of warning */
-  argv = argv; /* get rid of warning */
-
+int main (void) {
   zmbvu_open();
   decode_screens();
   zmbvu_close();


### PR DESCRIPTION
Instead of weird hacks to avoid warnings about unused `argc` and `argv` we use the proper `int main(void)` signature for the test programs.