### PR TITLE
Fix -Wint-to-pointer-cast warnings

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -185,7 +185,7 @@ static void encode_screens_to_bin (void) {
   write(fd, &scc, 4);
   // idxarray offset
   write(fd, &scc, 4);
-  do_encode_screens(writer_bin, (void *)fd);
+  do_encode_screens(writer_bin, (void *)(intptr_t)fd);
   // write idxarray
   scc = lseek(fd, 0, SEEK_CUR);
   write(fd, idxarray, index_ptr*sizeof(idxarray[0]));

--- a/src/unpack.c
+++ b/src/unpack.c
@@ -129,7 +129,7 @@ static void decode_screens (void) {
   if (fd < 0) { printf("FATAL: can't create output file!\n"); return; }
   scc = screen_count;
   write(fd, &scc, 4);
-  do_decode_screens(writer_bin, (void *)fd);
+  do_decode_screens(writer_bin, (void *)(intptr_t)fd);
   close(fd);
 }
 

--- a/src/unpack_small.c
+++ b/src/unpack_small.c
@@ -128,7 +128,7 @@ static void decode_screens (void) {
   if (fd < 0) { printf("FATAL: can't create output file!\n"); return; }
   scc = screen_count;
   write(fd, &scc, 4);
-  do_decode_screens(writer_bin, (void *)fd);
+  do_decode_screens(writer_bin, (void *)(intptr_t)fd);
   close(fd);
 }
 


### PR DESCRIPTION
Both clang 16 and gcc 13 complain about these casts. So we first cast to the type `intptr_t` which is guaranteed to be wide enough to hold a pointer value, before casting to `void*`.